### PR TITLE
add Electronegativity to the "Code review" section

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@
 
 ## Code review
 
+- [electronegativity](https://github.com/doyensec/electronegativity) - Static analysis tool to identify misconfigurations and security anti-patterns in Electron applications.
 - [eslint-plugin-security](https://github.com/nodesecurity/eslint-plugin-security) - This project will help identify potential security hotspots, but finds a lot of false positives which need triage by a human.
 - [repo-supervisor](https://github.com/auth0/repo-supervisor) - Scan your code for security misconfiguration, search for passwords and secrets.
 - [vuln-regex-detector](https://github.com/davisjam/vuln-regex-detector) - Detect vulnerable regexes. REDOS, catastrophic backtracking.


### PR DESCRIPTION
[Electronegativity](https://github.com/doyensec/electronegativity) is a tool to identify misconfigurations and security anti-patterns in Electron-based applications. Software developers and security auditors can use this tool to detect and mitigate potential weaknesses and implementation bugs when developing applications using Electron.

It already has its [npm package](https://npmjs.com/package/@doyensec/electronegativity) and is [actively maintained](https://github.com/doyensec/electronegativity/commits/master).